### PR TITLE
Refactor: Deduplicate cloud provider IP and metadata logic

### DIFF
--- a/common/generic_metadata.go
+++ b/common/generic_metadata.go
@@ -1,0 +1,84 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/ip-api/cloudip/util"
+)
+
+// EnsureMetadataFile checks if the metadata file exists. If not, it creates the directory
+// and the initial metadata file.
+func EnsureMetadataFile(metadataFilePath string, providerDir string, providerType CloudProviderType, initialMetadata *CloudMetadata) error {
+	if _, err := os.Stat(metadataFilePath); os.IsNotExist(err) {
+		VerboseOutput(fmt.Sprintf("Creating directory: %s", providerDir))
+		if mkdirErr := os.MkdirAll(providerDir, 0755); mkdirErr != nil {
+			return util.WrapError(mkdirErr, fmt.Sprintf("failed to create directory: %s", providerDir))
+		}
+
+		VerboseOutput(fmt.Sprintf("Creating initial metadata file for %s: %s", providerType, metadataFilePath))
+		if writeErr := WriteMetadata(metadataFilePath, initialMetadata); writeErr != nil {
+			return util.WrapError(writeErr, fmt.Sprintf("failed to write initial metadata file for %s", providerType))
+		}
+		return nil
+	} else if err != nil {
+		return util.WrapError(err, fmt.Sprintf("failed to stat metadata file: %s", metadataFilePath))
+	}
+	return nil
+}
+
+// ReadMetadata reads and unmarshals the JSON content from the metadata file.
+func ReadMetadata(metadataFilePath string, metadata *CloudMetadata) error {
+	file, err := os.Open(metadataFilePath)
+	if err != nil {
+		return util.WrapError(err, fmt.Sprintf("failed to open metadata file for reading: %s", metadataFilePath))
+	}
+	defer file.Close()
+
+	err = util.HandleJSON(nil, json.NewDecoder(file).Decode(&metadata), "decode metadata from file: "+metadataFilePath)
+	if err != nil {
+		return err // HandleJSON already wraps the error
+	}
+	return nil
+}
+
+// WriteMetadata marshals and writes the metadata struct to the specified file as JSON.
+func WriteMetadata(metadataFilePath string, metadata *CloudMetadata) error {
+	// Ensure the directory exists before trying to write the file
+	dir := filepath.Dir(metadataFilePath)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if mkdirErr := os.MkdirAll(dir, 0755); mkdirErr != nil {
+			return util.WrapError(mkdirErr, fmt.Sprintf("failed to create directory for metadata file: %s", dir))
+		}
+	}
+
+	file, err := os.OpenFile(metadataFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return util.WrapError(err, fmt.Sprintf("failed to open metadata file for writing: %s", metadataFilePath))
+	}
+	defer file.Close()
+
+	// Seek to the beginning of the file before writing
+	_, seekErr := file.Seek(0, io.SeekStart)
+	if seekErr != nil {
+		return util.WrapError(seekErr, fmt.Sprintf("failed to seek to beginning of metadata file: %s", metadataFilePath))
+	}
+
+	// Truncate the file to remove old content if any, especially after seeking.
+	// This is important if the new content is smaller than the old.
+	if truncErr := file.Truncate(0); truncErr != nil {
+		return util.WrapError(truncErr, fmt.Sprintf("failed to truncate metadata file: %s", metadataFilePath))
+	}
+
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ") // For pretty printing, consistent with existing logic
+	err = util.HandleJSON(nil, encoder.Encode(metadata), "encode metadata to file: "+metadataFilePath)
+	if err != nil {
+		return err // HandleJSON already wraps the error
+	}
+	return nil
+}

--- a/common/generic_metadata.go
+++ b/common/generic_metadata.go
@@ -38,7 +38,7 @@ func ReadMetadata(metadataFilePath string, metadata *CloudMetadata) error {
 	}
 	defer file.Close()
 
-	err = util.HandleJSON(nil, json.NewDecoder(file).Decode(&metadata), "decode metadata from file: "+metadataFilePath)
+	err = util.HandleJSON(nil, json.NewDecoder(file).Decode(metadata), "decode metadata from file: "+metadataFilePath)
 	if err != nil {
 		return err // HandleJSON already wraps the error
 	}

--- a/common/generic_metadata_test.go
+++ b/common/generic_metadata_test.go
@@ -1,0 +1,217 @@
+package common_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/ip-api/cloudip/common"
+	// "github.com/ip-api/cloudip/util" // Not directly used here, but common package might.
+)
+
+func TestEnsureMetadataFile_NewFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	providerDir := filepath.Join(tmpDir, "aws") // Using "aws" as a sample provider name
+	metadataFilePath := filepath.Join(providerDir, ".metadata.json")
+	initialMetadata := &common.CloudMetadata{
+		Type:         common.AWS,
+		LastModified: 1234567890,
+	}
+
+	err := common.EnsureMetadataFile(metadataFilePath, providerDir, common.AWS, initialMetadata)
+	if err != nil {
+		t.Fatalf("EnsureMetadataFile failed: %v", err)
+	}
+
+	// Verify provider directory was created
+	if _, err := os.Stat(providerDir); os.IsNotExist(err) {
+		t.Errorf("Provider directory %s was not created", providerDir)
+	}
+
+	// Verify metadata file was created
+	if _, err := os.Stat(metadataFilePath); os.IsNotExist(err) {
+		t.Errorf("Metadata file %s was not created", metadataFilePath)
+	}
+
+	// Verify initial metadata was written correctly
+	readMeta := &common.CloudMetadata{}
+	file, err := os.Open(metadataFilePath)
+	if err != nil {
+		t.Fatalf("Failed to open created metadata file: %v", err)
+	}
+	defer file.Close()
+
+	if err := json.NewDecoder(file).Decode(readMeta); err != nil {
+		t.Fatalf("Failed to decode metadata from created file: %v", err)
+	}
+
+	if !reflect.DeepEqual(readMeta, initialMetadata) {
+		t.Errorf("Written metadata %+v does not match initial metadata %+v", readMeta, initialMetadata)
+	}
+}
+
+func TestEnsureMetadataFile_ExistingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	providerDir := filepath.Join(tmpDir, "gcp")
+	metadataFilePath := filepath.Join(providerDir, ".metadata.json")
+
+	// Pre-create the directory and a metadata file with different content
+	if err := os.MkdirAll(providerDir, 0755); err != nil {
+		t.Fatalf("Failed to create provider directory for test: %v", err)
+	}
+	existingMetadata := &common.CloudMetadata{
+		Type:         common.GCP,
+		LastModified: 9876543210,
+	}
+	file, err := os.Create(metadataFilePath)
+	if err != nil {
+		t.Fatalf("Failed to create existing metadata file: %v", err)
+	}
+	if err := json.NewEncoder(file).Encode(existingMetadata); err != nil {
+		file.Close()
+		t.Fatalf("Failed to encode existing metadata: %v", err)
+	}
+	file.Close()
+
+	// Attempt to ensure the file again with different initial metadata
+	differentInitialMetadata := &common.CloudMetadata{
+		Type:         common.GCP,
+		LastModified: 1111111111,
+	}
+	err = common.EnsureMetadataFile(metadataFilePath, providerDir, common.GCP, differentInitialMetadata)
+	if err != nil {
+		t.Fatalf("EnsureMetadataFile failed for existing file: %v", err)
+	}
+
+	// Verify the file content has NOT changed
+	readMeta := &common.CloudMetadata{}
+	readFile, err := os.Open(metadataFilePath)
+	if err != nil {
+		t.Fatalf("Failed to open metadata file after EnsureMetadataFile call: %v", err)
+	}
+	defer readFile.Close()
+
+	if err := json.NewDecoder(readFile).Decode(readMeta); err != nil {
+		t.Fatalf("Failed to decode metadata from file after EnsureMetadataFile call: %v", err)
+	}
+
+	if !reflect.DeepEqual(readMeta, existingMetadata) {
+		t.Errorf("Existing metadata %+v was overwritten, expected %+v", readMeta, existingMetadata)
+	}
+}
+
+func TestWriteAndReadMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	metadataFilePath := filepath.Join(tmpDir, "test_meta.json")
+
+	originalMeta := &common.CloudMetadata{
+		Type:         common.Azure,
+		LastModified: 12345,
+		ETag:         "test-etag",
+		SyncToken:    "test-sync-token",
+	}
+
+	// Test WriteMetadata
+	err := common.WriteMetadata(metadataFilePath, originalMeta)
+	if err != nil {
+		t.Fatalf("WriteMetadata failed: %v", err)
+	}
+
+	// Test ReadMetadata
+	readMeta := &common.CloudMetadata{} // Target for reading
+	err = common.ReadMetadata(metadataFilePath, readMeta)
+	if err != nil {
+		t.Fatalf("ReadMetadata failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(readMeta, originalMeta) {
+		t.Errorf("Read metadata %+v does not match original metadata %+v", readMeta, originalMeta)
+	}
+}
+
+func TestReadMetadata_NonExistentFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	metadataFilePath := filepath.Join(tmpDir, "non_existent_meta.json")
+	readMeta := &common.CloudMetadata{}
+
+	err := common.ReadMetadata(metadataFilePath, readMeta)
+	if err == nil {
+		t.Error("ReadMetadata expected an error for non-existent file, got nil")
+	}
+}
+
+func TestReadMetadata_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	metadataFilePath := filepath.Join(tmpDir, "empty_meta.json")
+
+	// Create an empty file
+	file, err := os.Create(metadataFilePath)
+	if err != nil {
+		t.Fatalf("Failed to create empty file: %v", err)
+	}
+	file.Close()
+
+	readMeta := &common.CloudMetadata{}
+	err = common.ReadMetadata(metadataFilePath, readMeta)
+	if err == nil {
+		t.Error("ReadMetadata expected an error for empty file, got nil")
+	}
+	// More specific error check could be done here if desired (e.g., EOF or JSON syntax error)
+}
+
+func TestReadMetadata_MalformedJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	metadataFilePath := filepath.Join(tmpDir, "malformed_meta.json")
+
+	// Create a file with malformed JSON
+	err := os.WriteFile(metadataFilePath, []byte("{this is not valid json"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write malformed JSON file: %v", err)
+	}
+
+	readMeta := &common.CloudMetadata{}
+	err = common.ReadMetadata(metadataFilePath, readMeta)
+	if err == nil {
+		t.Error("ReadMetadata expected an error for malformed JSON, got nil")
+	}
+	// Check if it's a json.SyntaxError or similar
+	if _, ok := err.(*json.SyntaxError); !ok {
+		// common.ReadMetadata wraps the error, so we might not get SyntaxError directly
+		// t.Errorf("Expected json.SyntaxError or wrapped version, got %T: %v", err, err)
+		t.Logf("Note: Expected error for malformed JSON. Got type %T: %v", err, err)
+	}
+}
+
+func TestWriteMetadata_DirectoryCreation(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Path to a metadata file within a non-existent directory
+	newProviderDir := filepath.Join(tmpDir, "new_provider")
+	metadataFilePath := filepath.Join(newProviderDir, ".metadata.json")
+
+	metadataToWrite := &common.CloudMetadata{
+		Type:         common.AWS,
+		LastModified: 7890,
+	}
+
+	// WriteMetadata should create 'new_provider' directory
+	err := common.WriteMetadata(metadataFilePath, metadataToWrite)
+	if err != nil {
+		t.Fatalf("WriteMetadata failed when directory did not exist: %v", err)
+	}
+
+	// Verify file was created and content is correct
+	if _, err := os.Stat(metadataFilePath); os.IsNotExist(err) {
+		t.Errorf("Metadata file %s was not created by WriteMetadata", metadataFilePath)
+	}
+
+	readMeta := &common.CloudMetadata{}
+	err = common.ReadMetadata(metadataFilePath, readMeta)
+	if err != nil {
+		t.Fatalf("Failed to read metadata written by WriteMetadata (dir creation test): %v", err)
+	}
+	if !reflect.DeepEqual(readMeta, metadataToWrite) {
+		t.Errorf("Read metadata %+v does not match written metadata %+v (dir creation test)", readMeta, metadataToWrite)
+	}
+}

--- a/ip/aws/common.go
+++ b/ip/aws/common.go
@@ -1,19 +1,20 @@
 package aws
 
 import (
-	"cloudip/util"
-	"fmt"
+	"github.com/ip-api/cloudip/ip"
+	// "cloudip/util" // No longer used
+	// "fmt" // No longer used
 )
 
-var appDir = util.GetAppDir()
+// const DataFile = "aws.json" // This constant is used by DataFilePathAws below
+const DataFile = "aws.json" // Keeping this as it's specific to AWS and used by ip.GetDataFilePath
 
-const DataFile = "aws.json"
-const MetadataFile = ".metadata.json"
+// MetadataFile constant is removed as ip.GetMetadataFilePath uses ip.DefaultMetadataFile
 
 func getDaraUrl() string {
 	return "https://ip-ranges.amazonaws.com/ip-ranges.json"
 }
 
-var ProviderDirectory = fmt.Sprintf("%s/%s", appDir, "aws")
-var DataFilePathAws = fmt.Sprintf("%s/%s", ProviderDirectory, DataFile)
-var MetadataFilePathAws = fmt.Sprintf("%s/%s", ProviderDirectory, MetadataFile)
+var ProviderDirectory = ip.GetProviderDirectory("aws")
+var DataFilePathAws = ip.GetDataFilePath("aws", DataFile) // DataFile is defined above
+var MetadataFilePathAws = ip.GetMetadataFilePath("aws")

--- a/ip/aws/common.go
+++ b/ip/aws/common.go
@@ -11,7 +11,7 @@ const DataFile = "aws.json" // Keeping this as it's specific to AWS and used by 
 
 // MetadataFile constant is removed as ip.GetMetadataFilePath uses ip.DefaultMetadataFile
 
-func getDaraUrl() string {
+func getDataUrl() string {
 	return "https://ip-ranges.amazonaws.com/ip-ranges.json"
 }
 

--- a/ip/azure/common.go
+++ b/ip/azure/common.go
@@ -1,18 +1,19 @@
 package azure
 
 import (
-	"cloudip/util"
+	"cloudip/util" // Keep for PrintErrorTrace and ErrorWithInfo in getDataUrl
 	"errors"
-	"fmt"
+	"fmt" // Keep for Errorf in getDataUrl
 	"github.com/PuerkitoBio/goquery"
+	"github.com/ip-api/cloudip/ip" // Added for ip.Get... functions
 	"net/http"
 	"sync"
 )
 
-var appDir = util.GetAppDir()
+// var appDir = util.GetAppDir() // Removed
 
-const DataFile = "azure.json"
-const MetadataFile = ".metadata.json"
+const DataFile = "azure.json" // Keep: specific to Azure
+// const MetadataFile = ".metadata.json" // Removed: ip.GetMetadataFilePath uses ip.DefaultMetadataFile
 
 var dataRequestOnce sync.Once
 var dataUrl string = "" // return empty string when error
@@ -62,6 +63,6 @@ func getDataUrl() string {
 	return dataUrl
 }
 
-var ProviderDirectory = fmt.Sprintf("%s/%s", appDir, "azure")
-var DataFilePathAzure = fmt.Sprintf("%s/%s", ProviderDirectory, DataFile)
-var MetadataFilePathAzure = fmt.Sprintf("%s/%s", ProviderDirectory, MetadataFile)
+var ProviderDirectory = ip.GetProviderDirectory("azure")
+var DataFilePathAzure = ip.GetDataFilePath("azure", DataFile)
+var MetadataFilePathAzure = ip.GetMetadataFilePath("azure")

--- a/ip/azure/metadata.go
+++ b/ip/azure/metadata.go
@@ -4,8 +4,8 @@ import (
 	"cloudip/common"
 	"cloudip/util"
 	"fmt"
-	"io"
-	"os"
+	// "io" // No longer used
+	// "os" // No longer used
 )
 
 var metadataManager = &common.MetadataManager{
@@ -14,87 +14,30 @@ var metadataManager = &common.MetadataManager{
 		Type:         common.Azure,
 		LastModified: 0,
 	},
+	// Add a SaveFunc that uses the generic WriteMetadata
+	SaveFunc: func(filePath string, data *common.CloudMetadata) error {
+		return common.WriteMetadata(filePath, data)
+	},
 }
 
 func init() {
-	err := ensureMetadataFile()
+	initialMeta := &common.CloudMetadata{Type: common.Azure, LastModified: 0}
+	err := common.EnsureMetadataFile(MetadataFilePathAzure, ProviderDirectory, common.Azure, initialMeta)
 	if err != nil {
+		util.PrintErrorTrace(fmt.Errorf("Error ensuring Azure metadata file during init: %w", err))
 		return
 	}
 
-	err = readMetadata()
+	err = common.ReadMetadata(MetadataFilePathAzure, metadataManager.Metadata)
 	if err != nil {
-		util.PrintErrorTrace(util.ErrorWithInfo(err, "Error reading metadata"))
+		util.PrintErrorTrace(fmt.Errorf("Error reading Azure metadata during init: %w", err))
 		return
 	}
 }
 
-func ensureMetadataFile() error {
-	if !util.IsFileExists(metadataManager.MetadataFilePath) {
-		common.VerboseOutput(fmt.Sprintf("Creating %s ...", ProviderDirectory))
-		if err := os.MkdirAll(ProviderDirectory, 0755); err != nil {
-			return util.ErrorWithInfo(err, "Error creating azure directory")
-		}
-		metadataFile, err := os.Create(metadataManager.MetadataFilePath)
-		if err != nil {
-			return util.ErrorWithInfo(err, "Error creating metadata file")
-		}
-		defer func() {
-			if err := metadataFile.Close(); err != nil {
-				util.PrintErrorTrace(util.ErrorWithInfo(err, "Error closing metadata file"))
-			}
-		}()
-		err = writeMetadata(&common.CloudMetadata{
-			Type:         common.Azure,
-			LastModified: 0,
-		})
-		if err != nil {
-			return util.ErrorWithInfo(err, "Error writing metadata")
-		}
-	}
-
-	return nil
-}
-
-func readMetadata() error {
-	metadataFile, err := os.Open(metadataManager.MetadataFilePath)
-	if err != nil {
-		util.PrintErrorTrace(util.ErrorWithInfo(err, "Error opening metadata file"))
-		return err
-	}
-	defer func() {
-		if err := metadataFile.Close(); err != nil {
-			util.PrintErrorTrace(util.ErrorWithInfo(err, "Error closing metadata file"))
-		}
-	}()
-	err = util.HandleJSON(metadataFile, metadataManager.Metadata, "read")
-	if err != nil {
-		err = util.ErrorWithInfo(err, "Error reading metadata file")
-		return err
-	}
-	return nil
-}
-
-func writeMetadata(metadata *common.CloudMetadata) error {
-	metadataFile, err := os.OpenFile(metadataManager.MetadataFilePath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
-	if err != nil {
-		return util.ErrorWithInfo(err, "Error opening metadata file")
-	}
-	defer func() {
-		if err := metadataFile.Close(); err != nil {
-			util.PrintErrorTrace(util.ErrorWithInfo(err, "Error closing metadata file"))
-		}
-	}()
-	if _, err := metadataFile.Seek(0, io.SeekStart); err != nil {
-		return util.ErrorWithInfo(err, "Error seeking metadata file")
-	}
-	err = util.HandleJSON(metadataFile, metadata, "write")
-	if err != nil {
-		return util.ErrorWithInfo(err, "Error writing metadata")
-	}
-	err = readMetadata()
-	return err
-}
+// ensureMetadataFile, readMetadata, and writeMetadata are removed,
+// their functionality is replaced by common.EnsureMetadataFile,
+// common.ReadMetadata, and common.WriteMetadata respectively.
 
 func isExpired() bool {
 	lastModifiedDate, err := ipDataManagerAzure.GetLastModifiedUpstream()

--- a/ip/common.go
+++ b/ip/common.go
@@ -2,7 +2,28 @@ package ip
 
 import (
 	"cloudip/common"
+	"cloudip/util"
+	"fmt"
 )
+
+var AppDir = util.GetAppDir()
+
+const DefaultMetadataFile = ".metadata.json"
+
+// GetProviderDirectory returns the path to the provider-specific directory.
+func GetProviderDirectory(providerName string) string {
+	return fmt.Sprintf("%s/%s", AppDir, providerName)
+}
+
+// GetDataFilePath returns the full path to a provider's data file.
+func GetDataFilePath(providerName string, dataFileName string) string {
+	return fmt.Sprintf("%s/%s", GetProviderDirectory(providerName), dataFileName)
+}
+
+// GetMetadataFilePath returns the full path to a provider's metadata file.
+func GetMetadataFilePath(providerName string) string {
+	return fmt.Sprintf("%s/%s", GetProviderDirectory(providerName), DefaultMetadataFile)
+}
 
 var Providers = []common.CloudProvider{
 	"aws",

--- a/ip/gcp/check.go
+++ b/ip/gcp/check.go
@@ -1,59 +1,46 @@
 package gcp
 
 import (
-	"cloudip/util"
-	"fmt"
-	"net"
 	"sync"
+
+	"github.com/ip-api/cloudip/ip"
+	"github.com/ip-api/cloudip/util"
 )
 
-var v4Tree *util.CIDRTree
-var v6Tree *util.CIDRTree
-
-var initialized = false
-var initializeLock = sync.Mutex{}
+var gcpChecker = ip.NewCloudIpChecker()
+var initOnceGcp sync.Once
 
 func Initialize() {
-	if initialized {
-		return
-	}
-
-	initializeLock.Lock()
-	defer initializeLock.Unlock()
-
-	v4Tree = util.NewCIDRTree()
-	v6Tree = util.NewCIDRTree()
-
-	err := ipDataManagerGcp.EnsureDataFile()
-	if err != nil {
-		util.PrintErrorTrace(err)
-		return
-	}
-
-	gcpIpRangeData := *ipDataManagerGcp.LoadIpData()
-
-	for _, prefix := range gcpIpRangeData.Prefixes {
-		if prefix.Ipv4Prefix != "" {
-			v4Tree.AddCIDR(prefix.Ipv4Prefix)
-		} else if prefix.Ipv6Prefix != "" {
-			v6Tree.AddCIDR(prefix.Ipv6Prefix)
+	initOnceGcp.Do(func() {
+		err := ipDataManagerGcp.EnsureDataFile()
+		if err != nil {
+			util.PrintErrorTrace(err)
+			return
 		}
-	}
 
-	initialized = true
+		gcpIpRangeData := ipDataManagerGcp.LoadIpData()
+		if gcpIpRangeData == nil {
+			// Handle case where data loading fails
+			return
+		}
+
+		var ipv4Ranges []string
+		var ipv6Ranges []string
+
+		for _, prefix := range gcpIpRangeData.Prefixes {
+			if prefix.Ipv4Prefix != "" {
+				ipv4Ranges = append(ipv4Ranges, prefix.Ipv4Prefix)
+			}
+			// GCP data can have both IPv4 and IPv6 prefixes for the same entry,
+			// so we don't use else if here.
+			if prefix.Ipv6Prefix != "" {
+				ipv6Ranges = append(ipv6Ranges, prefix.Ipv6Prefix)
+			}
+		}
+		gcpChecker.Initialize(ipv4Ranges, ipv6Ranges)
+	})
 }
 
-func IsGcpIp(ip string) (bool, error) {
-	parsedIp := net.ParseIP(ip)
-	if parsedIp == nil {
-		return false, fmt.Errorf("Error parsing IP: %s", ip)
-	}
-
-	if parsedIp.To4() != nil {
-		return v4Tree.Match(ip), nil
-	}
-	if parsedIp.To16() != nil {
-		return v6Tree.Match(ip), nil
-	}
-	return false, nil
+func IsGcpIp(ipAddr string) (bool, error) {
+	return gcpChecker.IsCloudIp(ipAddr)
 }

--- a/ip/gcp/common.go
+++ b/ip/gcp/common.go
@@ -1,19 +1,20 @@
 package gcp
 
 import (
-	"cloudip/util"
-	"fmt"
+	"github.com/ip-api/cloudip/ip"
+	// "cloudip/util" // No longer used
+	// "fmt" // No longer used
 )
 
-var appDir = util.GetAppDir()
+// var appDir = util.GetAppDir() // Removed
 
-const DataFile = "gcp.json"
-const MetadataFile = ".metadata.json"
+const DataFile = "gcp.json" // Keep: specific to GCP
+// const MetadataFile = ".metadata.json" // Removed: ip.GetMetadataFilePath uses ip.DefaultMetadataFile
 
 func getDataUrl() string {
 	return "https://www.gstatic.com/ipranges/cloud.json"
 }
 
-var ProviderDirectory = fmt.Sprintf("%s/%s", appDir, "gcp")
-var DataFilePathGcp = fmt.Sprintf("%s/%s", ProviderDirectory, DataFile)
-var MetadataFilePathGcp = fmt.Sprintf("%s/%s", ProviderDirectory, MetadataFile)
+var ProviderDirectory = ip.GetProviderDirectory("gcp")
+var DataFilePathGcp = ip.GetDataFilePath("gcp", DataFile)
+var MetadataFilePathGcp = ip.GetMetadataFilePath("gcp")

--- a/ip/gcp/metadata.go
+++ b/ip/gcp/metadata.go
@@ -4,8 +4,8 @@ import (
 	"cloudip/common"
 	"cloudip/util"
 	"fmt"
-	"io"
-	"os"
+	// "io" // No longer used
+	// "os" // No longer used
 )
 
 var metadataManager = &common.MetadataManager{
@@ -14,87 +14,30 @@ var metadataManager = &common.MetadataManager{
 		Type:         common.GCP,
 		LastModified: 0,
 	},
+	// Add a SaveFunc that uses the generic WriteMetadata
+	SaveFunc: func(filePath string, data *common.CloudMetadata) error {
+		return common.WriteMetadata(filePath, data)
+	},
 }
 
 func init() {
-	err := ensureMetadataFile()
+	initialMeta := &common.CloudMetadata{Type: common.GCP, LastModified: 0}
+	err := common.EnsureMetadataFile(MetadataFilePathGcp, ProviderDirectory, common.GCP, initialMeta)
 	if err != nil {
+		util.PrintErrorTrace(fmt.Errorf("Error ensuring GCP metadata file during init: %w", err))
 		return
 	}
 
-	err = readMetadata()
+	err = common.ReadMetadata(MetadataFilePathGcp, metadataManager.Metadata)
 	if err != nil {
-		util.PrintErrorTrace(util.ErrorWithInfo(err, "Error reading metadata"))
+		util.PrintErrorTrace(fmt.Errorf("Error reading GCP metadata during init: %w", err))
 		return
 	}
 }
 
-func ensureMetadataFile() error {
-	if !util.IsFileExists(metadataManager.MetadataFilePath) {
-		common.VerboseOutput(fmt.Sprintf("Creating %s ...", ProviderDirectory))
-		if err := os.MkdirAll(ProviderDirectory, 0755); err != nil {
-			return util.ErrorWithInfo(err, "Error creating gcp directory")
-		}
-		metadataFile, err := os.Create(metadataManager.MetadataFilePath)
-		if err != nil {
-			return util.ErrorWithInfo(err, "Error creating metadata file")
-		}
-		defer func() {
-			if err := metadataFile.Close(); err != nil {
-				util.PrintErrorTrace(util.ErrorWithInfo(err, "Error closing metadata file"))
-			}
-		}()
-		err = writeMetadata(&common.CloudMetadata{
-			Type:         common.GCP,
-			LastModified: 0,
-		})
-		if err != nil {
-			return util.ErrorWithInfo(err, "Error writing metadata")
-		}
-	}
-
-	return nil
-}
-
-func readMetadata() error {
-	metadataFile, err := os.Open(metadataManager.MetadataFilePath)
-	if err != nil {
-		util.PrintErrorTrace(util.ErrorWithInfo(err, "Error opening metadata file"))
-		return err
-	}
-	defer func() {
-		if err := metadataFile.Close(); err != nil {
-			util.PrintErrorTrace(util.ErrorWithInfo(err, "Error closing metadata file"))
-		}
-	}()
-	err = util.HandleJSON(metadataFile, metadataManager.Metadata, "read")
-	if err != nil {
-		err = util.ErrorWithInfo(err, "Error reading metadata file")
-		return err
-	}
-	return nil
-}
-
-func writeMetadata(metadata *common.CloudMetadata) error {
-	metadataFile, err := os.Create(metadataManager.MetadataFilePath)
-	if err != nil {
-		return util.ErrorWithInfo(err, "Error creating metadata file")
-	}
-	defer func() {
-		if err := metadataFile.Close(); err != nil {
-			util.PrintErrorTrace(util.ErrorWithInfo(err, "Error closing metadata file"))
-		}
-	}()
-	if _, err := metadataFile.Seek(0, io.SeekStart); err != nil {
-		return util.ErrorWithInfo(err, "Error seeking metadata file")
-	}
-	err = util.HandleJSON(metadataFile, metadata, "write")
-	if err != nil {
-		return err
-	}
-	err = readMetadata()
-	return err
-}
+// ensureMetadataFile, readMetadata, and writeMetadata are removed,
+// their functionality is replaced by common.EnsureMetadataFile,
+// common.ReadMetadata, and common.WriteMetadata respectively.
 
 func isExpired() bool {
 	lastModifiedDate, err := ipDataManagerGcp.GetLastModifiedUpstream()

--- a/ip/ip_checker.go
+++ b/ip/ip_checker.go
@@ -1,0 +1,51 @@
+package ip
+
+import (
+	"net"
+	"sync"
+
+	"github.com/ip-api/cloudip/util"
+)
+
+// CloudIpChecker holds CIDR trees for IPv4 and IPv6 addresses.
+type CloudIpChecker struct {
+	ipv4Tree *util.CIDRTree
+	ipv6Tree *util.CIDRTree
+	initOnce sync.Once
+}
+
+// NewCloudIpChecker initializes and returns a new CloudIpChecker.
+func NewCloudIpChecker() *CloudIpChecker {
+	return &CloudIpChecker{
+		ipv4Tree: util.NewCIDRTree(),
+		ipv6Tree: util.NewCIDRTree(),
+	}
+}
+
+// Initialize populates the CIDR trees with the provided IP ranges.
+// It ensures that initialization happens only once.
+func (c *CloudIpChecker) Initialize(ipv4Ranges []string, ipv6Ranges []string) {
+	c.initOnce.Do(func() {
+		for _, cidr := range ipv4Ranges {
+			c.ipv4Tree.AddCIDR(cidr)
+		}
+		for _, cidr := range ipv6Ranges {
+			c.ipv6Tree.AddCIDR(cidr)
+		}
+	})
+}
+
+// IsCloudIp checks if the given IP string belongs to a cloud provider.
+// It returns true if the IP is found in the CIDR trees, false otherwise,
+// and an error if the IP string is invalid.
+func (c *CloudIpChecker) IsCloudIp(ipStr string) (bool, error) {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false, &net.ParseError{Type: "IP address", Text: ipStr}
+	}
+
+	if ip.To4() != nil {
+		return c.ipv4Tree.Contains(ip), nil
+	}
+	return c.ipv6Tree.Contains(ip), nil
+}

--- a/ip/ip_checker_test.go
+++ b/ip/ip_checker_test.go
@@ -1,0 +1,291 @@
+package ip
+
+import (
+	"testing"
+)
+
+func TestNewCloudIpChecker(t *testing.T) {
+	checker := NewCloudIpChecker()
+	if checker == nil {
+		t.Fatal("NewCloudIpChecker() returned nil")
+	}
+	if checker.ipv4Tree == nil {
+		t.Error("NewCloudIpChecker().ipv4Tree is nil")
+	}
+	if checker.ipv6Tree == nil {
+		t.Error("NewCloudIpChecker().ipv6Tree is nil")
+	}
+}
+
+func TestInitializeAndIsCloudIp(t *testing.T) {
+	checker := NewCloudIpChecker()
+
+	initialIPv4Ranges := []string{"10.0.0.0/8", "172.16.0.0/12"}
+	initialIPv6Ranges := []string{"2001:db8::/32"}
+
+	checker.Initialize(initialIPv4Ranges, initialIPv6Ranges)
+
+	testCases := []struct {
+		name        string
+		ip          string
+		expectMatch bool
+		expectError bool
+	}{
+		{"IPv4 in initial range 1", "10.1.2.3", true, false},
+		{"IPv4 in initial range 2", "172.20.0.1", true, false},
+		{"IPv4 not in initial range", "1.1.1.1", false, false},
+		{"IPv6 in initial range", "2001:db8:1:2::1", true, false},
+		{"IPv6 not in initial range", "2002::1", false, false},
+		{"Invalid IP", "not-an-ip", false, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name+"_initial_load", func(t *testing.T) {
+			match, err := checker.IsCloudIp(tc.ip)
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error for IP %s, got nil", tc.ip)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for IP %s: %v", tc.ip, err)
+				}
+			}
+			if match != tc.expectMatch {
+				t.Errorf("Expected match %v for IP %s, got %v", tc.expectMatch, tc.ip, match)
+			}
+		})
+	}
+
+	// Test sync.Once: try to initialize again with different ranges
+	differentIPv4Ranges := []string{"192.168.0.0/16"}
+	differentIPv6Ranges := []string{"2003:cafe::/32"}
+	checker.Initialize(differentIPv4Ranges, differentIPv6Ranges)
+
+	// Re-run tests; they should still match against the *initial* ranges
+	t.Run("sync_once_check", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name+"_after_second_init_attempt", func(t *testing.T) {
+				match, err := checker.IsCloudIp(tc.ip)
+				if tc.expectError {
+					if err == nil {
+						t.Errorf("Expected error for IP %s, got nil (after 2nd init)", tc.ip)
+					}
+				} else {
+					if err != nil {
+						t.Errorf("Unexpected error for IP %s: %v (after 2nd init)", tc.ip, err)
+					}
+				}
+				if match != tc.expectMatch {
+					t.Errorf("Expected match %v for IP %s, got %v (after 2nd init - sync.Once failed?)", tc.expectMatch, tc.ip, match)
+				}
+			})
+		}
+		// Explicitly check if an IP from the *different* range matches (it shouldn't)
+		match, _ := checker.IsCloudIp("192.168.1.1")
+		if match {
+			t.Errorf("IP 192.168.1.1 from second init attempt matched, sync.Once failed")
+		}
+		match, _ = checker.IsCloudIp("2003:cafe::1")
+		if match {
+			t.Errorf("IP 2003:cafe::1 from second init attempt matched, sync.Once failed")
+		}
+	})
+}
+
+func TestInitializeEmptyRanges(t *testing.T) {
+	checker := NewCloudIpChecker()
+	checker.Initialize([]string{}, []string{})
+
+	testIPs := []string{"10.1.2.3", "2001:db8::1", "0.0.0.0"}
+	for _, ip := range testIPs {
+		t.Run(ip, func(t *testing.T) {
+			match, err := checker.IsCloudIp(ip)
+			if err != nil {
+				t.Errorf("Unexpected error for IP %s: %v", ip, err)
+			}
+			if match {
+				t.Errorf("Expected no match for IP %s with empty ranges, got match", ip)
+			}
+		})
+	}
+}
+
+func TestInitializeOnlyV4(t *testing.T) {
+	checker := NewCloudIpChecker()
+	v4Ranges := []string{"192.0.2.0/24"}
+	checker.Initialize(v4Ranges, []string{})
+
+	testCases := []struct {
+		name        string
+		ip          string
+		expectMatch bool
+	}{
+		{"IPv4 in range", "192.0.2.100", true},
+		{"IPv4 not in range", "198.51.100.1", false},
+		{"IPv6 any", "2001:db8::1", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			match, err := checker.IsCloudIp(tc.ip)
+			if err != nil {
+				t.Errorf("Unexpected error for IP %s: %v", tc.ip, err)
+			}
+			if match != tc.expectMatch {
+				t.Errorf("Expected match %v for IP %s, got %v", tc.expectMatch, tc.ip, match)
+			}
+		})
+	}
+}
+
+func TestInitializeOnlyV6(t *testing.T) {
+	checker := NewCloudIpChecker()
+	v6Ranges := []string{"2001:db8:abcd::/48"}
+	checker.Initialize([]string{}, v6Ranges)
+
+	testCases := []struct {
+		name        string
+		ip          string
+		expectMatch bool
+	}{
+		{"IPv6 in range", "2001:db8:abcd:0001::1234", true},
+		{"IPv6 not in range", "2001:db8:ffff::1", false},
+		{"IPv4 any", "192.0.2.1", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			match, err := checker.IsCloudIp(tc.ip)
+			if err != nil {
+				t.Errorf("Unexpected error for IP %s: %v", tc.ip, err)
+			}
+			if match != tc.expectMatch {
+				t.Errorf("Expected match %v for IP %s, got %v", tc.expectMatch, tc.ip, match)
+			}
+		})
+	}
+}
+
+// Test case for an IPv4 address when only IPv6 ranges are loaded
+func TestIsCloudIp_IPv4_OnlyIPv6Loaded(t *testing.T) {
+	checker := NewCloudIpChecker()
+	checker.Initialize([]string{}, []string{"2001:db8::/32"})
+	match, err := checker.IsCloudIp("10.1.2.3")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if match {
+		t.Error("Expected false for IPv4 check when only IPv6 ranges are loaded, got true")
+	}
+}
+
+// Test case for an IPv6 address when only IPv4 ranges are loaded
+func TestIsCloudIp_IPv6_OnlyIPv4Loaded(t *testing.T) {
+	checker := NewCloudIpChecker()
+	checker.Initialize([]string{"10.0.0.0/8"}, []string{})
+	match, err := checker.IsCloudIp("2001:db8::1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if match {
+		t.Error("Expected false for IPv6 check when only IPv4 ranges are loaded, got true")
+	}
+}
+
+// Test case for Initialize being called multiple times (sync.Once specific detailed check)
+// This is partially covered in TestInitializeAndIsCloudIp, but can be more direct.
+func TestInitialize_SyncOnce_Direct(t *testing.T) {
+	checker := NewCloudIpChecker()
+
+	firstIPv4 := []string{"1.1.1.0/24"}
+	firstIPv6 := []string{"2001::/120"}
+	checker.Initialize(firstIPv4, firstIPv6)
+
+	// Check if an IP from the first set matches
+	match, _ := checker.IsCloudIp("1.1.1.1")
+	if !match {
+		t.Error("IP from first init (1.1.1.1) did not match after first init")
+	}
+	match, _ = checker.IsCloudIp("2001::1")
+	if !match {
+		t.Error("IP from first init (2001::1) did not match after first init")
+	}
+
+
+	secondIPv4 := []string{"2.2.2.0/24"}
+	secondIPv6 := []string{"2002::/120"}
+	// Attempt to re-initialize. This should not change the underlying trees.
+	checker.Initialize(secondIPv4, secondIPv6)
+
+	// Check again if an IP from the first set matches (it should)
+	match, _ = checker.IsCloudIp("1.1.1.1")
+	if !match {
+		t.Error("IP from first init (1.1.1.1) did not match after second init attempt")
+	}
+	match, _ = checker.IsCloudIp("2001::1")
+	if !match {
+		t.Error("IP from first init (2001::1) did not match after second init attempt")
+	}
+
+	// Check if an IP from the second set matches (it should NOT)
+	match, _ = checker.IsCloudIp("2.2.2.1")
+	if match {
+		t.Error("IP from second init (2.2.2.1) matched, sync.Once failed")
+	}
+	match, _ = checker.IsCloudIp("2002::1")
+	if match {
+		t.Error("IP from second init (2002::1) matched, sync.Once failed")
+	}
+}
+
+// Test for IsCloudIp with nil trees (should not happen with NewCloudIpChecker, but defensive)
+// This test might be of limited value as NewCloudIpChecker ensures non-nil trees.
+// And Initialize would panic if trees were nil and it tried to add.
+// However, if the internal structure of CloudIpChecker changed, this might be relevant.
+// For now, this is more of a conceptual test.
+func TestIsCloudIp_NilTrees(t *testing.T) {
+	checker := &CloudIpChecker{} // Intentionally creating a checker without NewCloudIpChecker
+	// This will cause a panic if IsCloudIp tries to access methods on nil trees.
+	// A more robust test would check if IsCloudIp handles this gracefully,
+	// but current implementation would panic, which is a valid failure.
+	// We expect IsCloudIp to not panic if trees are nil, but rather return false.
+	// However, the current util.CIDRTree.Contains() would panic.
+	// So, this test verifies current behavior or highlights a potential fragility
+	// if trees could somehow become nil post-initialization (which they shouldn't).
+
+	// Let's ensure our test setup itself doesn't panic immediately
+	if checker.ipv4Tree != nil || checker.ipv6Tree != nil {
+		t.Log("Skipping direct nil tree test as trees are somehow initialized or this test needs rethink")
+		return
+	}
+	
+	// Test with an IP. If Contains panics on nil receiver, this test will fail.
+	// This implicitly tests that IsCloudIp doesn't proceed if trees are nil,
+	// or that Contains() on a nil tree (if that were possible) returns false.
+	// Given current CIDRTree, Contains() on nil tree would panic.
+	// The CloudIpChecker.IsCloudIp itself does not check for nil trees before calling Contains.
+	// This is acceptable because NewCloudIpChecker guarantees non-nil trees.
+	
+	// A "safer" version of this test:
+	checkerWithNilTree := NewCloudIpChecker() // Start with a valid one
+	checkerWithNilTree.ipv4Tree = nil          // Force a nil tree (only possible in same package)
+	
+	match, err := checkerWithNilTree.IsCloudIp("1.2.3.4")
+	if err != nil {
+		t.Errorf("IsCloudIp with one nil tree returned error: %v", err)
+	}
+	if match {
+		t.Errorf("IsCloudIp with one nil tree returned match true, expected false")
+	}
+
+	checkerWithNilTree.ipv4Tree = checkerWithNilTree.ipv6Tree // restore for next part
+	checkerWithNilTree.ipv6Tree = nil 
+	match, err = checkerWithNilTree.IsCloudIp("2001:db8::1")
+	if err != nil {
+		t.Errorf("IsCloudIp with other nil tree returned error: %v", err)
+	}
+	if match {
+		t.Errorf("IsCloudIp with other nil tree returned match true, expected false")
+	}
+}


### PR DESCRIPTION
This commit introduces generic components for IP address checking and metadata file handling, significantly reducing code duplication across AWS, Azure, and GCP provider packages.

Key changes:

- Added `ip/ip_checker.go` with a generic `CloudIpChecker` to manage CIDR tree initialization and IP matching. Provider-specific `check.go` files now delegate to this generic checker.

- Added `common/generic_metadata.go` with functions for ensuring, reading, and writing metadata files. Provider-specific `metadata.go` files now use these generic functions, reducing duplicated file I/O and JSON handling logic.

- Centralized common path definitions (application directory, default metadata filename) and path generation logic into `ip/common.go`. Provider-specific `common.go` files were updated to use these new shared utilities.

These changes improve code maintainability and consistency. The next step is to add unit tests for the new generic components.