### PR TITLE
fix(#81): improve cli error output

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,9 @@ Download the latest binary from the [Releases](https://github.com/jongwoo328/clo
     ```
     Output:
     ```json
-    [{"IP":"54.230.176.25","Provider":"aws"}]
+    [{"ip":"54.230.176.25","provider":"aws","error":""}]
     ```
+    JSON output uses lowercase keys: `ip`, `provider`, and `error`. If an IP check fails, `provider` is set to `error` and the `error` field contains the reason.
 
   - `csv`: This tool does not have a direct `--format=csv` option. 
     However, you can produce CSV-like output by combining `--format=text` with `--delimiter=','`.
@@ -191,6 +192,9 @@ Download the latest binary from the [Releases](https://github.com/jongwoo328/clo
   AWS IP ranges updated [2024-12-27 04:12:30]
   54.230.176.25 aws
   ```
+
+### Error Handling
+If one or more IP checks fail, `cloudip` still prints all result rows and exits with a non-zero status code. In `text` and `table` formats, failed rows show `ERROR` in the provider column and detailed error messages are written to stderr. In `json` format, each row includes an `error` field.
 
 
 ---

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -26,6 +26,12 @@ var headers = map[string]string{
 	"Provider": "Provider",
 }
 
+type jsonResult struct {
+	IP       string `json:"ip"`
+	Provider string `json:"provider"`
+	Error    string `json:"error"`
+}
+
 func printResult(results *[]common.Result, flags *common.CloudIpFlag) error {
 	switch flags.Format {
 	case "text":
@@ -69,13 +75,14 @@ func printResultAsTable(results *[]common.Result, flags *common.CloudIpFlag) {
 }
 
 func printResultAsJson(results *[]common.Result) error {
-	resultSlice := make([]map[string]string, 0)
+	resultSlice := make([]jsonResult, 0, len(*results))
 	for _, r := range *results {
-		resultMap := map[string]string{
-			headers["IP"]:       r.Ip,
-			headers["Provider"]: getProviderString(r),
+		result := jsonResult{
+			IP:       r.Ip,
+			Provider: getJSONProviderString(r),
+			Error:    getErrorString(r),
 		}
-		resultSlice = append(resultSlice, resultMap)
+		resultSlice = append(resultSlice, result)
 	}
 	bytes, err := json.Marshal(resultSlice)
 	if err != nil {
@@ -83,4 +90,18 @@ func printResultAsJson(results *[]common.Result) error {
 	}
 	fmt.Println(string(bytes))
 	return nil
+}
+
+func getJSONProviderString(r common.Result) string {
+	if r.Error != nil {
+		return "error"
+	}
+	return getProviderString(r)
+}
+
+func getErrorString(r common.Result) string {
+	if r.Error == nil {
+		return ""
+	}
+	return r.Error.Error()
 }

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -32,7 +32,7 @@ type jsonResult struct {
 	Error    string `json:"error"`
 }
 
-func printResult(results *[]common.Result, flags *common.CloudIpFlag) error {
+func printResult(results []common.Result, flags *common.CloudIpFlag) error {
 	switch flags.Format {
 	case "text":
 		printResultAsText(results, flags)
@@ -46,15 +46,15 @@ func printResult(results *[]common.Result, flags *common.CloudIpFlag) error {
 	return nil
 }
 
-func printResultAsText(results *[]common.Result, flags *common.CloudIpFlag) {
+func printResultAsText(results []common.Result, flags *common.CloudIpFlag) {
 	if flags.Header {
 		fmt.Printf("%s%s%s\n", headers["IP"], flags.Delimiter, headers["Provider"])
 	}
-	for _, r := range *results {
+	for _, r := range results {
 		fmt.Printf("%s%s%s\n", r.Ip, flags.Delimiter, getProviderString(r))
 	}
 }
-func printResultAsTable(results *[]common.Result, flags *common.CloudIpFlag) {
+func printResultAsTable(results []common.Result, flags *common.CloudIpFlag) {
 	table := tablewriter.NewTable(os.Stdout,
 		tablewriter.WithRenderer(renderer.NewBlueprint(tw.Rendition{
 			Borders:  tw.Border{Left: tw.Off, Right: tw.Off, Top: tw.Off, Bottom: tw.Off},
@@ -68,15 +68,15 @@ func printResultAsTable(results *[]common.Result, flags *common.CloudIpFlag) {
 	)
 
 	table.Header(headers["IP"], headers["Provider"])
-	for _, r := range *results {
+	for _, r := range results {
 		table.Append(r.Ip, getProviderString(r))
 	}
 	table.Render()
 }
 
-func printResultAsJson(results *[]common.Result) error {
-	resultSlice := make([]jsonResult, 0, len(*results))
-	for _, r := range *results {
+func printResultAsJson(results []common.Result) error {
+	resultSlice := make([]jsonResult, 0, len(results))
+	for _, r := range results {
 		result := jsonResult{
 			IP:       r.Ip,
 			Provider: getJSONProviderString(r),

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -74,7 +74,7 @@ func TestPrintResultDispatchesFormat(t *testing.T) {
 
 			var err error
 			output := captureStdout(t, func() {
-				err = printResult(&results, flags)
+				err = printResult(results, flags)
 			})
 
 			if err != nil {
@@ -94,7 +94,7 @@ func TestPrintResultDispatchesFormat(t *testing.T) {
 
 		var err error
 		output := captureStdout(t, func() {
-			err = printResult(&results, flags)
+			err = printResult(results, flags)
 		})
 
 		if err != nil {
@@ -110,7 +110,7 @@ func TestPrintResultDispatchesFormat(t *testing.T) {
 		_, flags := newTestCmd(t)
 		flags.Format = "yaml"
 
-		err := printResult(&results, flags)
+		err := printResult(results, flags)
 
 		if err == nil {
 			t.Error("expected error for invalid format, got nil")
@@ -175,7 +175,7 @@ func TestPrintResultAsText(t *testing.T) {
 			flags.Header = tt.header
 
 			output := captureStdout(t, func() {
-				printResultAsText(&tt.results, flags)
+				printResultAsText(tt.results, flags)
 			})
 
 			lines := strings.Split(strings.TrimSpace(output), "\n")
@@ -202,7 +202,7 @@ func TestPrintResultAsTable(t *testing.T) {
 	}
 
 	output := captureStdout(t, func() {
-		printResultAsTable(&results, flags)
+		printResultAsTable(results, flags)
 	})
 
 	lines := strings.Split(strings.TrimSpace(output), "\n")
@@ -240,7 +240,7 @@ func TestPrintResultAsTableAlwaysHasHeader(t *testing.T) {
 	}
 
 	output := captureStdout(t, func() {
-		printResultAsTable(&results, flags)
+		printResultAsTable(results, flags)
 	})
 
 	if !strings.Contains(output, "Provider") {
@@ -294,7 +294,7 @@ func TestPrintResultAsJson(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			output := captureStdout(t, func() {
-				printResultAsJson(&tt.results)
+				printResultAsJson(tt.results)
 			})
 
 			var parsed []map[string]string

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -63,7 +63,7 @@ func TestPrintResultDispatchesFormat(t *testing.T) {
 		{
 			name:     "dispatches to json",
 			format:   "json",
-			expected: `[{"IP":"1.2.3.4","Provider":"aws"}]`,
+			expected: `[{"ip":"1.2.3.4","provider":"aws","error":""}]`,
 		},
 	}
 
@@ -263,8 +263,8 @@ func TestPrintResultAsJson(t *testing.T) {
 				{Ip: "5.6.7.8", Provider: ""},
 			},
 			expected: []map[string]string{
-				{"IP": "1.2.3.4", "Provider": "aws"},
-				{"IP": "5.6.7.8", "Provider": "unknown"},
+				{"ip": "1.2.3.4", "provider": "aws", "error": ""},
+				{"ip": "5.6.7.8", "provider": "unknown", "error": ""},
 			},
 		},
 		{
@@ -275,9 +275,18 @@ func TestPrintResultAsJson(t *testing.T) {
 				{Ip: "3.3.3.3", Provider: common.Azure},
 			},
 			expected: []map[string]string{
-				{"IP": "1.1.1.1", "Provider": "aws"},
-				{"IP": "2.2.2.2", "Provider": "gcp"},
-				{"IP": "3.3.3.3", "Provider": "azure"},
+				{"ip": "1.1.1.1", "provider": "aws", "error": ""},
+				{"ip": "2.2.2.2", "provider": "gcp", "error": ""},
+				{"ip": "3.3.3.3", "provider": "azure", "error": ""},
+			},
+		},
+		{
+			name: "error result",
+			results: []common.Result{
+				{Ip: "bad-ip", Error: fmt.Errorf("error parsing IP: bad-ip")},
+			},
+			expected: []map[string]string{
+				{"ip": "bad-ip", "provider": "error", "error": "error parsing IP: bad-ip"},
 			},
 		},
 	}
@@ -298,7 +307,7 @@ func TestPrintResultAsJson(t *testing.T) {
 			}
 
 			for i, want := range tt.expected {
-				if parsed[i]["IP"] != want["IP"] || parsed[i]["Provider"] != want["Provider"] {
+				if parsed[i]["ip"] != want["ip"] || parsed[i]["provider"] != want["provider"] || parsed[i]["error"] != want["error"] {
 					t.Errorf("item %d: expected %v, got %v", i, want, parsed[i])
 				}
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,21 +3,32 @@ package cmd
 import (
 	"cloudip/common"
 	"cloudip/ip"
+	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
+	"io"
 )
 
 var Version string
 
 func NewRootCmd(flags *common.CloudIpFlag, checker *ip.IPChecker) *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   common.AppName,
-		Short: fmt.Sprintf("%s is a CLI tool for identifying whether an IP address belongs to a major cloud provider (e.g., AWS, GCP).", common.AppName),
-		Args:  cobra.ArbitraryArgs,
+		Use:           common.AppName,
+		Short:         fmt.Sprintf("%s is a CLI tool for identifying whether an IP address belongs to a major cloud provider (e.g., AWS, GCP).", common.AppName),
+		Args:          cobra.ArbitraryArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			common.SetVerbose(flags.Verbose)
 			result := checker.Check(args)
-			return printResult(&result, flags)
+			if err := printResult(&result, flags); err != nil {
+				return err
+			}
+			if !hasResultError(result) {
+				return nil
+			}
+			printResultErrors(cmd.ErrOrStderr(), result)
+			return errors.New("one or more IP checks failed")
 		},
 	}
 
@@ -37,4 +48,22 @@ func NewRootCmd(flags *common.CloudIpFlag, checker *ip.IPChecker) *cobra.Command
 	rootCmd.Flags().BoolVarP(&flags.Verbose, "verbose", "v", false, "Print verbose output")
 
 	return rootCmd
+}
+
+func hasResultError(results []common.Result) bool {
+	for _, result := range results {
+		if result.Error != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func printResultErrors(w io.Writer, results []common.Result) {
+	for _, result := range results {
+		if result.Error == nil {
+			continue
+		}
+		fmt.Fprintf(w, "%s: %v\n", result.Ip, result.Error)
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ func NewRootCmd(flags *common.CloudIpFlag, checker *ip.IPChecker) *cobra.Command
 		RunE: func(cmd *cobra.Command, args []string) error {
 			common.SetVerbose(flags.Verbose)
 			result := checker.Check(args)
-			if err := printResult(&result, flags); err != nil {
+			if err := printResult(result, flags); err != nil {
 				return err
 			}
 			if !hasResultError(result) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"cloudip/common"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -119,5 +120,69 @@ func TestFlagBinding(t *testing.T) {
 			}
 			tt.verify(t, flags)
 		})
+	}
+}
+
+func TestRootCmdReturnsErrorWhenAnyResultHasError(t *testing.T) {
+	cmd, _ := newTestCmd(t)
+	stderr := new(bytes.Buffer)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"bad-ip", "8.8.8.8"})
+
+	var err error
+	stdout := captureStdout(t, func() {
+		err = cmd.Execute()
+	})
+
+	if err == nil {
+		t.Fatal("expected command error for invalid IP")
+	}
+	if !strings.Contains(stdout, "bad-ip ERROR") {
+		t.Fatalf("expected stdout to include error row, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "8.8.8.8 unknown") {
+		t.Fatalf("expected stdout to include successful unknown row, got %q", stdout)
+	}
+	if !strings.Contains(stderr.String(), "bad-ip: error parsing IP: bad-ip") {
+		t.Fatalf("expected stderr to include detailed error, got %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "Usage:") {
+		t.Fatalf("stderr should not include usage for result errors, got %q", stderr.String())
+	}
+}
+
+func TestRootCmdJSONErrorOutputIsValidJSON(t *testing.T) {
+	cmd, _ := newTestCmd(t)
+	stderr := new(bytes.Buffer)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"--format", "json", "bad-ip", "8.8.8.8"})
+
+	var err error
+	stdout := captureStdout(t, func() {
+		err = cmd.Execute()
+	})
+
+	if err == nil {
+		t.Fatal("expected command error for invalid IP")
+	}
+
+	var parsed []map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v, stdout: %q", err, stdout)
+	}
+	if len(parsed) != 2 {
+		t.Fatalf("expected 2 JSON rows, got %d: %v", len(parsed), parsed)
+	}
+	if parsed[0]["ip"] != "bad-ip" || parsed[0]["provider"] != "error" || parsed[0]["error"] == "" {
+		t.Fatalf("unexpected error row: %v", parsed[0])
+	}
+	if parsed[1]["ip"] != "8.8.8.8" || parsed[1]["provider"] != "unknown" || parsed[1]["error"] != "" {
+		t.Fatalf("unexpected unknown row: %v", parsed[1])
+	}
+	if !strings.Contains(stderr.String(), "bad-ip: error parsing IP: bad-ip") {
+		t.Fatalf("expected stderr to include detailed error, got %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "Usage:") {
+		t.Fatalf("stderr should not include usage for result errors, got %q", stderr.String())
 	}
 }

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -161,8 +161,9 @@ yay -S cloudip
     ```
     출력:
     ```json
-    [{"IP":"54.230.176.25","Provider":"aws"}]
+    [{"ip":"54.230.176.25","provider":"aws","error":""}]
     ```
+    JSON 출력은 `ip`, `provider`, `error` 소문자 키를 사용합니다. IP 검사에 실패하면 `provider`는 `error`가 되고 `error` 필드에 실패 원인이 들어갑니다.
 
   - `csv`: CSV 형식은 `--format=csv` 옵션을 직접 지원하지 않습니다. 
     대신, `--format=text` 와 `--delimiter=','` 옵션을 함께 사용하여 CSV와 유사한 형식으로 출력할 수 있습니다. 헤더를 포함하려면 `--header` 옵션을 추가합니다.
@@ -188,6 +189,9 @@ yay -S cloudip
   AWS IP ranges updated [2024-12-27 04:12:30]
   54.230.176.25 aws
   ```
+
+### 에러 처리 (Error Handling)
+하나 이상의 IP 검사에 실패해도 `cloudip`는 모든 결과 행을 출력한 뒤 non-zero 종료 코드를 반환합니다. `text`와 `table` 형식에서는 실패한 행의 provider 컬럼에 `ERROR`를 표시하고, 상세 에러 메시지는 stderr로 출력합니다. `json` 형식에서는 각 행의 `error` 필드에 에러 원인을 포함합니다.
 
 ---
 

--- a/util/error.go
+++ b/util/error.go
@@ -3,6 +3,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 )
 
@@ -16,7 +17,7 @@ func ErrorWithInfo(e error, msg string) error {
 
 func PrintErrorTrace(e error) {
 	for e != nil {
-		fmt.Println("Error:", e)
+		fmt.Fprintln(os.Stderr, "Error:", e)
 		e = errors.Unwrap(e)
 	}
 }


### PR DESCRIPTION
## Summary
- Return a non-zero exit code when any IP check result contains an error, while still printing all result rows.
- Add JSON output fields with lowercase keys: `ip`, `provider`, and `error`.
- Keep text/table output compatible by preserving the existing `ERROR` provider value and moving detailed errors to stderr.
- Document the updated JSON/error behavior in English and Korean READMEs.

## Validation
- `go test ./cmd -count=1`
- `go test ./...`
- `go test -race ./...`
- `go build ./...`
- `go vet ./...`
- `go run . --format=json bad-ip` exits non-zero and prints valid JSON to stdout plus details to stderr.

Close #81