### PR TITLE
fix(#83): route cli output through command writer

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -4,7 +4,7 @@ import (
 	"cloudip/common"
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/renderer"
@@ -32,30 +32,34 @@ type jsonResult struct {
 	Error    string `json:"error"`
 }
 
-func printResult(results []common.Result, flags *common.CloudIpFlag) error {
+func printResult(w io.Writer, results []common.Result, flags *common.CloudIpFlag) error {
 	switch flags.Format {
 	case "text":
-		printResultAsText(results, flags)
+		return printResultAsText(w, results, flags)
 	case "table":
-		printResultAsTable(results, flags)
+		return printResultAsTable(w, results, flags)
 	case "json":
-		return printResultAsJson(results)
+		return printResultAsJson(w, results)
 	default:
 		return fmt.Errorf("invalid output format: %s. Supported formats are: text, table, json", flags.Format)
 	}
-	return nil
 }
 
-func printResultAsText(results []common.Result, flags *common.CloudIpFlag) {
+func printResultAsText(w io.Writer, results []common.Result, flags *common.CloudIpFlag) error {
 	if flags.Header {
-		fmt.Printf("%s%s%s\n", headers["IP"], flags.Delimiter, headers["Provider"])
+		if _, err := fmt.Fprintf(w, "%s%s%s\n", headers["IP"], flags.Delimiter, headers["Provider"]); err != nil {
+			return fmt.Errorf("error writing text result: %w", err)
+		}
 	}
 	for _, r := range results {
-		fmt.Printf("%s%s%s\n", r.Ip, flags.Delimiter, getProviderString(r))
+		if _, err := fmt.Fprintf(w, "%s%s%s\n", r.Ip, flags.Delimiter, getProviderString(r)); err != nil {
+			return fmt.Errorf("error writing text result: %w", err)
+		}
 	}
+	return nil
 }
-func printResultAsTable(results []common.Result, flags *common.CloudIpFlag) {
-	table := tablewriter.NewTable(os.Stdout,
+func printResultAsTable(w io.Writer, results []common.Result, flags *common.CloudIpFlag) error {
+	table := tablewriter.NewTable(w,
 		tablewriter.WithRenderer(renderer.NewBlueprint(tw.Rendition{
 			Borders:  tw.Border{Left: tw.Off, Right: tw.Off, Top: tw.Off, Bottom: tw.Off},
 			Symbols:  tw.NewSymbolCustom("delim").WithColumn(flags.Delimiter),
@@ -71,10 +75,13 @@ func printResultAsTable(results []common.Result, flags *common.CloudIpFlag) {
 	for _, r := range results {
 		table.Append(r.Ip, getProviderString(r))
 	}
-	table.Render()
+	if err := table.Render(); err != nil {
+		return fmt.Errorf("error writing table result: %w", err)
+	}
+	return nil
 }
 
-func printResultAsJson(results []common.Result) error {
+func printResultAsJson(w io.Writer, results []common.Result) error {
 	resultSlice := make([]jsonResult, 0, len(results))
 	for _, r := range results {
 		result := jsonResult{
@@ -88,7 +95,9 @@ func printResultAsJson(results []common.Result) error {
 	if err != nil {
 		return fmt.Errorf("error converting result to JSON: %w", err)
 	}
-	fmt.Println(string(bytes))
+	if _, err := fmt.Fprintln(w, string(bytes)); err != nil {
+		return fmt.Errorf("error writing JSON result: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"cloudip/common"
 	"encoding/json"
 	"fmt"
@@ -73,15 +74,14 @@ func TestPrintResultDispatchesFormat(t *testing.T) {
 			flags.Format = tt.format
 
 			var err error
-			output := captureStdout(t, func() {
-				err = printResult(results, flags)
-			})
+			output := new(bytes.Buffer)
+			err = printResult(output, results, flags)
 
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			got := strings.TrimSpace(output)
+			got := strings.TrimSpace(output.String())
 			if got != tt.expected {
 				t.Errorf("format '%s': expected %q, got %q", tt.format, tt.expected, got)
 			}
@@ -93,16 +93,15 @@ func TestPrintResultDispatchesFormat(t *testing.T) {
 		flags.Format = "table"
 
 		var err error
-		output := captureStdout(t, func() {
-			err = printResult(results, flags)
-		})
+		output := new(bytes.Buffer)
+		err = printResult(output, results, flags)
 
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if !strings.Contains(output, "1.2.3.4") || !strings.Contains(output, "aws") {
-			t.Errorf("format 'table': expected output to contain '1.2.3.4' and 'aws', got %q", output)
+		if !strings.Contains(output.String(), "1.2.3.4") || !strings.Contains(output.String(), "aws") {
+			t.Errorf("format 'table': expected output to contain '1.2.3.4' and 'aws', got %q", output.String())
 		}
 	})
 
@@ -110,7 +109,8 @@ func TestPrintResultDispatchesFormat(t *testing.T) {
 		_, flags := newTestCmd(t)
 		flags.Format = "yaml"
 
-		err := printResult(results, flags)
+		output := new(bytes.Buffer)
+		err := printResult(output, results, flags)
 
 		if err == nil {
 			t.Error("expected error for invalid format, got nil")
@@ -174,13 +174,14 @@ func TestPrintResultAsText(t *testing.T) {
 			flags.Delimiter = tt.delimiter
 			flags.Header = tt.header
 
-			output := captureStdout(t, func() {
-				printResultAsText(tt.results, flags)
-			})
+			output := new(bytes.Buffer)
+			if err := printResultAsText(output, tt.results, flags); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-			lines := strings.Split(strings.TrimSpace(output), "\n")
+			lines := strings.Split(strings.TrimSpace(output.String()), "\n")
 			if len(lines) != len(tt.expected) {
-				t.Fatalf("expected %d lines, got %d: %q", len(tt.expected), len(lines), output)
+				t.Fatalf("expected %d lines, got %d: %q", len(tt.expected), len(lines), output.String())
 			}
 			for i, want := range tt.expected {
 				if lines[i] != want {
@@ -201,15 +202,16 @@ func TestPrintResultAsTable(t *testing.T) {
 		{Ip: "5.6.7.8", Provider: common.Azure},
 	}
 
-	output := captureStdout(t, func() {
-		printResultAsTable(results, flags)
-	})
+	output := new(bytes.Buffer)
+	if err := printResultAsTable(output, results, flags); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-	lines := strings.Split(strings.TrimSpace(output), "\n")
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
 
 	// header + 2 data rows
 	if len(lines) != 3 {
-		t.Fatalf("expected 3 lines (header + 2 data), got %d: %q", len(lines), output)
+		t.Fatalf("expected 3 lines (header + 2 data), got %d: %q", len(lines), output.String())
 	}
 
 	// header is first line
@@ -239,12 +241,13 @@ func TestPrintResultAsTableAlwaysHasHeader(t *testing.T) {
 		{Ip: "10.0.0.1", Provider: common.AWS},
 	}
 
-	output := captureStdout(t, func() {
-		printResultAsTable(results, flags)
-	})
+	output := new(bytes.Buffer)
+	if err := printResultAsTable(output, results, flags); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-	if !strings.Contains(output, "Provider") {
-		t.Errorf("expected table to always include header, but 'Provider' not found in output: %q", output)
+	if !strings.Contains(output.String(), "Provider") {
+		t.Errorf("expected table to always include header, but 'Provider' not found in output: %q", output.String())
 	}
 }
 
@@ -293,13 +296,14 @@ func TestPrintResultAsJson(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := captureStdout(t, func() {
-				printResultAsJson(tt.results)
-			})
+			output := new(bytes.Buffer)
+			if err := printResultAsJson(output, tt.results); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
 			var parsed []map[string]string
-			if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed); err != nil {
-				t.Fatalf("output is not valid JSON: %v, output: %q", err, output)
+			if err := json.Unmarshal([]byte(strings.TrimSpace(output.String())), &parsed); err != nil {
+				t.Fatalf("output is not valid JSON: %v, output: %q", err, output.String())
 			}
 
 			if len(parsed) != len(tt.expected) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ func NewRootCmd(flags *common.CloudIpFlag, checker *ip.IPChecker) *cobra.Command
 		RunE: func(cmd *cobra.Command, args []string) error {
 			common.SetVerbose(flags.Verbose)
 			result := checker.Check(args)
-			if err := printResult(result, flags); err != nil {
+			if err := printResult(cmd.OutOrStdout(), result, flags); err != nil {
 				return err
 			}
 			if !hasResultError(result) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -39,6 +39,23 @@ func TestVersionCmdRejectsArgs(t *testing.T) {
 	}
 }
 
+func TestRootCmdUsesConfiguredOutputWriter(t *testing.T) {
+	cmd, _ := newTestCmd(t)
+	stdout := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetArgs([]string{"8.8.8.8"})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := strings.TrimSpace(stdout.String())
+	if got != "8.8.8.8 unknown" {
+		t.Errorf("expected configured output writer to receive result, got %q", got)
+	}
+}
+
 func TestFlagDefaults(t *testing.T) {
 	cmd, _ := newTestCmd(t)
 	flags := cmd.Flags()


### PR DESCRIPTION
## Summary
- Route root command result output through `cmd.OutOrStdout()`.
- Change text, table, and JSON output helpers to write to an injected `io.Writer` instead of global stdout.
- Propagate writer/render errors from output helpers.
- Update tests to use buffer-backed writers and verify `cmd.SetOut()` captures root command output.

## Validation
- `go test ./cmd -count=1`
- `go test ./...`
- `go test -race ./...`
- `go build ./...`
- `go vet ./...`

Close #83