### PR TITLE
fix(#87): clean provider messages and metadata guard

### DIFF
--- a/common/metadata.go
+++ b/common/metadata.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (m *MetadataManager) Ensure() error {
-	if m.Metadata == nil {
+	if m == nil || m.Metadata == nil {
 		return errors.New("metadata is not initialized")
 	}
 

--- a/common/metadata.go
+++ b/common/metadata.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (m *MetadataManager) Ensure() error {
+	if m.Metadata == nil {
+		return errors.New("metadata is not initialized")
+	}
+
 	if !util.IsFileExists(m.MetadataFilePath) {
 		VerboseOutput(fmt.Sprintf("Creating %s ...", m.ProviderDir))
 		if err := os.MkdirAll(m.ProviderDir, 0755); err != nil {

--- a/common/metadata_test.go
+++ b/common/metadata_test.go
@@ -136,3 +136,11 @@ func TestMetadataManagerMarkCheckedRequiresMetadata(t *testing.T) {
 		t.Fatal("MarkChecked() error = nil, want error")
 	}
 }
+
+func TestMetadataManagerEnsureRequiresMetadata(t *testing.T) {
+	manager := &MetadataManager{}
+
+	if err := manager.Ensure(); err == nil {
+		t.Fatal("Ensure() error = nil, want error")
+	}
+}

--- a/common/metadata_test.go
+++ b/common/metadata_test.go
@@ -138,9 +138,14 @@ func TestMetadataManagerMarkCheckedRequiresMetadata(t *testing.T) {
 }
 
 func TestMetadataManagerEnsureRequiresMetadata(t *testing.T) {
-	manager := &MetadataManager{}
+	var manager *MetadataManager
 
 	if err := manager.Ensure(); err == nil {
-		t.Fatal("Ensure() error = nil, want error")
+		t.Fatal("Ensure() error = nil for nil manager, want error")
+	}
+
+	manager = &MetadataManager{}
+	if err := manager.Ensure(); err == nil {
+		t.Fatal("Ensure() error = nil for nil metadata, want error")
 	}
 }

--- a/ip/aws/ip_data.go
+++ b/ip/aws/ip_data.go
@@ -118,9 +118,9 @@ func (ipDataManagerAws *IpDataManagerAws) EnsureDataFile() error {
 	}
 
 	if !util.IsFileExists(ipDataManagerAws.DataFilePath) {
-		common.VerboseOutput("AWS IP ranges file not exists.")
+		common.VerboseOutput("AWS IP ranges file does not exist.")
 		if ipDataManagerAws.UpdatePolicy.NoUpdate {
-			return errors.New("AWS IP ranges file not exists and --no-update is enabled")
+			return errors.New("AWS IP ranges file does not exist and --no-update is enabled")
 		}
 		// Download the AWS IP ranges file
 		err := ipDataManagerAws.downloadData()

--- a/ip/azure/ip_data.go
+++ b/ip/azure/ip_data.go
@@ -133,9 +133,9 @@ func (ipDataManagerAzure *IpDataManagerAzure) EnsureDataFile() error {
 	}
 
 	if !util.IsFileExists(ipDataManagerAzure.DataFilePath) {
-		common.VerboseOutput("Azure IP ranged file not exists.")
+		common.VerboseOutput("Azure IP ranges file does not exist.")
 		if ipDataManagerAzure.UpdatePolicy.NoUpdate {
-			return errors.New("Azure IP ranges file not exists and --no-update is enabled")
+			return errors.New("Azure IP ranges file does not exist and --no-update is enabled")
 		}
 		err := ipDataManagerAzure.downloadData()
 		return err
@@ -157,14 +157,14 @@ func (ipDataManagerAzure *IpDataManagerAzure) EnsureDataFile() error {
 		return nil
 	}
 	if expired {
-		common.VerboseOutput("Azure IP ranged are outdated. Updating to the latest version...")
+		common.VerboseOutput("Azure IP ranges are outdated. Updating to the latest version...")
 		err := ipDataManagerAzure.downloadData()
 		return err
 	}
 	if err := metadataManager.MarkChecked(time.Now()); err != nil {
 		return util.ErrorWithInfo(err, "error writing metadata")
 	}
-	common.VerboseOutput("Azure IP ranged are up-to-date.")
+	common.VerboseOutput("Azure IP ranges are up-to-date.")
 
 	return nil
 }

--- a/ip/cloudflare/ip_data.go
+++ b/ip/cloudflare/ip_data.go
@@ -110,9 +110,9 @@ func (m *IpDataManagerCloudflare) EnsureDataFile() error {
 	}
 
 	if !util.IsFileExists(m.DataFilePathV4) || !util.IsFileExists(m.DataFilePathV6) {
-		common.VerboseOutput("Cloudflare IP ranges file not exists.")
+		common.VerboseOutput("Cloudflare IP ranges file does not exist.")
 		if m.UpdatePolicy.NoUpdate {
-			return errors.New("Cloudflare IP ranges file not exists and --no-update is enabled")
+			return errors.New("Cloudflare IP ranges file does not exist and --no-update is enabled")
 		}
 		return m.downloadData()
 	}

--- a/ip/gcp/ip_data.go
+++ b/ip/gcp/ip_data.go
@@ -106,9 +106,9 @@ func (ipDataManagerGcp *IpDataManagerGcp) EnsureDataFile() error {
 	}
 
 	if !util.IsFileExists(ipDataManagerGcp.DataFilePath) {
-		common.VerboseOutput("GCP IP ranges file not exists.")
+		common.VerboseOutput("GCP IP ranges file does not exist.")
 		if ipDataManagerGcp.UpdatePolicy.NoUpdate {
-			return errors.New("GCP IP ranges file not exists and --no-update is enabled")
+			return errors.New("GCP IP ranges file does not exist and --no-update is enabled")
 		}
 		err := ipDataManagerGcp.downloadData()
 		return err


### PR DESCRIPTION
## Summary
- Correct provider missing-file verbose/error messages to use `file does not exist`
- Fix Azure verbose text from `ranged` to `ranges`
- Add a defensive nil metadata guard in `MetadataManager.Ensure()`
- Add a focused test for the new `Ensure()` guard

## Validation
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `git diff --check`

Close #87