### PR TITLE
fix(#89): stop AddCIDR writing to stdout

### DIFF
--- a/ip/aws/provider.go
+++ b/ip/aws/provider.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"cloudip/ip/provider"
+	"cloudip/util"
 )
 
 type AWSProvider struct {
@@ -17,11 +18,17 @@ func NewAWSProvider() *AWSProvider {
 			}
 
 			for _, prefix := range awsIpRangeData.Prefixes {
-				bp.AddIPv4Range(prefix.IpPrefix)
+				if err := bp.AddIPv4Range(prefix.IpPrefix); err != nil {
+					util.PrintErrorTrace(util.ErrorWithInfo(err, "error parsing CIDR: "+prefix.IpPrefix))
+					continue
+				}
 			}
 
 			for _, prefix := range awsIpRangeData.Ipv6Prefixes {
-				bp.AddIPv6Range(prefix.Ipv6Prefix)
+				if err := bp.AddIPv6Range(prefix.Ipv6Prefix); err != nil {
+					util.PrintErrorTrace(util.ErrorWithInfo(err, "error parsing CIDR: "+prefix.Ipv6Prefix))
+					continue
+				}
 			}
 
 			return nil

--- a/ip/cloudflare/provider.go
+++ b/ip/cloudflare/provider.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"cloudip/ip/provider"
+	"cloudip/util"
 )
 
 type CloudflareProvider struct {
@@ -17,11 +18,17 @@ func NewCloudflareProvider() *CloudflareProvider {
 			}
 
 			for _, cidr := range data.V4CIDRs {
-				bp.AddIPv4Range(cidr)
+				if err := bp.AddIPv4Range(cidr); err != nil {
+					util.PrintErrorTrace(util.ErrorWithInfo(err, "error parsing CIDR: "+cidr))
+					continue
+				}
 			}
 
 			for _, cidr := range data.V6CIDRs {
-				bp.AddIPv6Range(cidr)
+				if err := bp.AddIPv6Range(cidr); err != nil {
+					util.PrintErrorTrace(util.ErrorWithInfo(err, "error parsing CIDR: "+cidr))
+					continue
+				}
 			}
 
 			return nil

--- a/ip/gcp/provider.go
+++ b/ip/gcp/provider.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"cloudip/ip/provider"
+	"cloudip/util"
 )
 
 type GCPProvider struct {
@@ -18,9 +19,15 @@ func NewGCPProvider() *GCPProvider {
 
 			for _, prefix := range gcpIpRangeData.Prefixes {
 				if prefix.Ipv4Prefix != "" {
-					bp.AddIPv4Range(prefix.Ipv4Prefix)
+					if err := bp.AddIPv4Range(prefix.Ipv4Prefix); err != nil {
+						util.PrintErrorTrace(util.ErrorWithInfo(err, "error parsing CIDR: "+prefix.Ipv4Prefix))
+						continue
+					}
 				} else if prefix.Ipv6Prefix != "" {
-					bp.AddIPv6Range(prefix.Ipv6Prefix)
+					if err := bp.AddIPv6Range(prefix.Ipv6Prefix); err != nil {
+						util.PrintErrorTrace(util.ErrorWithInfo(err, "error parsing CIDR: "+prefix.Ipv6Prefix))
+						continue
+					}
 				}
 			}
 

--- a/ip/provider/provider.go
+++ b/ip/provider/provider.go
@@ -99,12 +99,12 @@ func (bp *BaseProvider) Initialize() error {
 	return nil
 }
 
-func (bp *BaseProvider) AddIPv4Range(cidr string) {
-	bp.v4Tree.AddCIDR(cidr)
+func (bp *BaseProvider) AddIPv4Range(cidr string) error {
+	return bp.v4Tree.AddCIDR(cidr)
 }
 
-func (bp *BaseProvider) AddIPv6Range(cidr string) {
-	bp.v6Tree.AddCIDR(cidr)
+func (bp *BaseProvider) AddIPv6Range(cidr string) error {
+	return bp.v6Tree.AddCIDR(cidr)
 }
 
 func (bp *BaseProvider) AddCIDRRange(cidr string) error {
@@ -114,9 +114,7 @@ func (bp *BaseProvider) AddCIDRRange(cidr string) error {
 	}
 
 	if cidrVersion == util.IPv4 {
-		bp.AddIPv4Range(cidr)
-	} else {
-		bp.AddIPv6Range(cidr)
+		return bp.AddIPv4Range(cidr)
 	}
-	return nil
+	return bp.AddIPv6Range(cidr)
 }

--- a/ip/provider/provider.go
+++ b/ip/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"cloudip/common"
 	"cloudip/util"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -100,10 +101,22 @@ func (bp *BaseProvider) Initialize() error {
 }
 
 func (bp *BaseProvider) AddIPv4Range(cidr string) error {
+	if bp == nil {
+		return errors.New("provider is not initialized")
+	}
+	if bp.v4Tree == nil {
+		return fmt.Errorf("provider %s is not initialized", bp.name)
+	}
 	return bp.v4Tree.AddCIDR(cidr)
 }
 
 func (bp *BaseProvider) AddIPv6Range(cidr string) error {
+	if bp == nil {
+		return errors.New("provider is not initialized")
+	}
+	if bp.v6Tree == nil {
+		return fmt.Errorf("provider %s is not initialized", bp.name)
+	}
 	return bp.v6Tree.AddCIDR(cidr)
 }
 

--- a/ip/provider/provider_test.go
+++ b/ip/provider/provider_test.go
@@ -289,6 +289,25 @@ func TestBaseProvider_AddIPRanges(t *testing.T) {
 	}
 }
 
+func TestBaseProvider_AddIPRangesBeforeInitializeReturnsError(t *testing.T) {
+	bp := NewBaseProvider("TestProvider", &mockDataManager{}, func(bp *BaseProvider) error { return nil })
+
+	if err := bp.AddIPv4Range("192.168.1.0/24"); err == nil {
+		t.Fatal("AddIPv4Range() error = nil, want error before Initialize")
+	}
+	if err := bp.AddIPv6Range("2001:db8::/32"); err == nil {
+		t.Fatal("AddIPv6Range() error = nil, want error before Initialize")
+	}
+
+	var nilProvider *BaseProvider
+	if err := nilProvider.AddIPv4Range("192.168.1.0/24"); err == nil {
+		t.Fatal("AddIPv4Range() error = nil, want error for nil provider")
+	}
+	if err := nilProvider.AddIPv6Range("2001:db8::/32"); err == nil {
+		t.Fatal("AddIPv6Range() error = nil, want error for nil provider")
+	}
+}
+
 func TestBaseProvider_AddCIDRRange(t *testing.T) {
 	mockDM := &mockDataManager{}
 	bp := NewBaseProvider("TestProvider", mockDM, func(bp *BaseProvider) error { return nil })

--- a/util/cidr_tree.go
+++ b/util/cidr_tree.go
@@ -20,11 +20,10 @@ func NewCIDRTree() *CIDRTree {
 }
 
 // AddCIDR Add CIDR to tree
-func (tree *CIDRTree) AddCIDR(cidr string) {
+func (tree *CIDRTree) AddCIDR(cidr string) error {
 	_, ipNet, err := net.ParseCIDR(cidr)
 	if err != nil {
-		fmt.Printf("Invalid CIDR: %s, error: %v\n", cidr, err)
-		return // Invalid CIDR
+		return fmt.Errorf("invalid CIDR %q: %w", cidr, err)
 	}
 
 	maskSize, _ := ipNet.Mask.Size()
@@ -40,6 +39,7 @@ func (tree *CIDRTree) AddCIDR(cidr string) {
 	}
 	node.IsLeaf = true
 	node.CIDR = cidr
+	return nil
 }
 
 // Match Verify that the IP belongs to one of the CIDRs in the CIDR tree

--- a/util/cidr_tree_test.go
+++ b/util/cidr_tree_test.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"io"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -35,4 +38,54 @@ func TestAddCIDRAndMatch(t *testing.T) {
 			t.Errorf("Failed: %s - got %v, expected %v", test.description, result, test.expected)
 		}
 	}
+}
+
+func TestAddCIDRInvalidReturnsErrorWithoutStdout(t *testing.T) {
+	tree := NewCIDRTree()
+
+	stdout := captureStdout(t, func() {
+		err := tree.AddCIDR("invalid-cidr")
+		if err == nil {
+			t.Fatal("AddCIDR() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "invalid CIDR") {
+			t.Fatalf("AddCIDR() error = %q, want invalid CIDR context", err.Error())
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("AddCIDR() wrote to stdout: %q", stdout)
+	}
+}
+
+type captureResult struct {
+	output string
+	err    error
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	origStdout := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	done := make(chan captureResult)
+	go func() {
+		out, err := io.ReadAll(r)
+		done <- captureResult{output: string(out), err: err}
+	}()
+
+	fn()
+	w.Close()
+
+	result := <-done
+	if result.err != nil {
+		t.Fatalf("failed to read captured stdout: %v", result.err)
+	}
+	return result.output
 }

--- a/util/cidr_tree_test.go
+++ b/util/cidr_tree_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -74,14 +75,26 @@ func captureStdout(t *testing.T, fn func()) string {
 	os.Stdout = w
 	defer func() { os.Stdout = origStdout }()
 
-	done := make(chan captureResult)
+	var closeOnce sync.Once
+	var closeErr error
+	closeWriter := func() {
+		closeOnce.Do(func() {
+			closeErr = w.Close()
+		})
+	}
+	defer closeWriter()
+
+	done := make(chan captureResult, 1)
 	go func() {
 		out, err := io.ReadAll(r)
 		done <- captureResult{output: string(out), err: err}
 	}()
 
 	fn()
-	w.Close()
+	closeWriter()
+	if closeErr != nil {
+		t.Fatalf("failed to close captured stdout: %v", closeErr)
+	}
 
 	result := <-done
 	if result.err != nil {


### PR DESCRIPTION
## Summary
- Change `CIDRTree.AddCIDR` to return invalid CIDR errors instead of writing to stdout
- Propagate `AddIPv4Range` / `AddIPv6Range` errors through `BaseProvider`
- Keep provider loading tolerant of bad CIDRs by logging diagnostics to stderr and continuing
- Add a focused test that invalid CIDRs return an error without stdout output

## Validation
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `git diff --check`

Close #89