### PR TITLE
refactor(#93): pass update policy at check time

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,11 +20,9 @@ func NewRootCmd(flags *common.CloudIpFlag, checker *ip.IPChecker) *cobra.Command
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			common.SetVerbose(flags.Verbose)
-			checker.SetUpdatePolicy(common.UpdatePolicy{
-				NoUpdate: flags.NoUpdate,
-				TTL:      common.DefaultUpdateCheckTTL,
-			})
-			result := checker.Check(args)
+			policy := common.DefaultUpdatePolicy()
+			policy.NoUpdate = flags.NoUpdate
+			result := checker.Check(args, policy)
 			if err := printResult(cmd.OutOrStdout(), result, flags); err != nil {
 				return err
 			}

--- a/ip/check.go
+++ b/ip/check.go
@@ -11,19 +11,16 @@ import (
 type IPChecker struct {
 	providers     map[common.CloudProvider]provider.CloudProvider
 	providerOrder []common.CloudProvider
-	updatePolicy  common.UpdatePolicy
 }
 
 func NewIPChecker(providers map[common.CloudProvider]provider.CloudProvider, order []common.CloudProvider) *IPChecker {
 	return &IPChecker{
 		providers:     providers,
 		providerOrder: order,
-		updatePolicy:  common.DefaultUpdatePolicy(),
 	}
 }
 
-func (c *IPChecker) SetUpdatePolicy(policy common.UpdatePolicy) {
-	c.updatePolicy = policy
+func (c *IPChecker) applyUpdatePolicy(policy common.UpdatePolicy) {
 	for _, p := range c.providers {
 		if setter, ok := p.(provider.UpdatePolicySetter); ok {
 			setter.SetUpdatePolicy(policy)
@@ -31,7 +28,9 @@ func (c *IPChecker) SetUpdatePolicy(policy common.UpdatePolicy) {
 	}
 }
 
-func (c *IPChecker) Check(ips []string) []common.Result {
+func (c *IPChecker) Check(ips []string, policy common.UpdatePolicy) []common.Result {
+	c.applyUpdatePolicy(policy)
+
 	results := make([]common.Result, len(ips))
 
 	for index, ip := range ips {

--- a/ip/check_test.go
+++ b/ip/check_test.go
@@ -68,6 +68,15 @@ func (m *mockProvider) GetName() string {
 	return m.name
 }
 
+type updatePolicyMockProvider struct {
+	mockProvider
+	policy common.UpdatePolicy
+}
+
+func (m *updatePolicyMockProvider) SetUpdatePolicy(policy common.UpdatePolicy) {
+	m.policy = policy
+}
+
 func TestCheckerCheck(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -160,7 +169,7 @@ func TestCheckerCheck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			checker := NewIPChecker(tt.mockProviders, DefaultProviderOrder)
-			results := checker.Check([]string{tt.ip})
+			results := checker.Check([]string{tt.ip}, common.DefaultUpdatePolicy())
 
 			if len(results) != 1 {
 				t.Fatalf("Expected 1 result, got %d", len(results))
@@ -220,7 +229,7 @@ func TestCheck(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			results := checker.Check(tt.ips)
+			results := checker.Check(tt.ips, common.DefaultUpdatePolicy())
 
 			if len(results) != tt.expectedLen {
 				t.Errorf("Expected %d results, got %d", tt.expectedLen, len(results))
@@ -248,7 +257,7 @@ func TestCheckWithProviderOrder(t *testing.T) {
 	)
 
 	ips := []string{"192.168.1.1"}
-	results := checker.Check(ips)
+	results := checker.Check(ips, common.DefaultUpdatePolicy())
 
 	if len(results) != 1 {
 		t.Fatalf("Expected 1 result, got %d", len(results))
@@ -257,5 +266,27 @@ func TestCheckWithProviderOrder(t *testing.T) {
 	// Should only match AWS (first in provider order)
 	if results[0].Provider != common.AWS {
 		t.Errorf("Expected AWS, got %q", results[0].Provider)
+	}
+}
+
+func TestCheckAppliesUpdatePolicyAtCheckTime(t *testing.T) {
+	mockProvider := &updatePolicyMockProvider{
+		mockProvider: *newMockProvider("AWS", false, false, false),
+	}
+	checker := NewIPChecker(
+		map[common.CloudProvider]provider.CloudProvider{
+			common.AWS: mockProvider,
+		},
+		DefaultProviderOrder,
+	)
+
+	policy := common.UpdatePolicy{
+		NoUpdate: true,
+		TTL:      common.DefaultUpdateCheckTTL,
+	}
+	checker.Check([]string{"8.8.8.8"}, policy)
+
+	if mockProvider.policy != policy {
+		t.Fatalf("policy = %+v, want %+v", mockProvider.policy, policy)
 	}
 }


### PR DESCRIPTION
## Summary
- Remove unused `IPChecker.updatePolicy` state and the public checker policy setter
- Pass `UpdatePolicy` directly to `Check()` at execution time
- Keep provider policy propagation internal to `IPChecker`
- Add coverage for check-time policy propagation

## Validation
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`

Close #93